### PR TITLE
change URL for reading to working one

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ The first thing you should read when joining @algorithm_club is the <a href="htt
 ## Schedule
 * November 23rd, 2015: The Relevance of Algorithms
 * 17.00 GMT/London, 12.00 EST/New York, 09.00 PST/Portland (sorry west coast)
-* <a href="http://www.tarletongillespie.org/essays/Gillespie%20-%20The%20Relevance%20of%20Algorithms.pdf">The Relvance of Algorithms</a> by Tarleton Gillespie
+* <a href="http://mixedrealitycity.org/readings/Gillespie_TheRelevanceofAlgorithms.pdf">The Relvance of Algorithms</a> by Tarleton Gillespie


### PR DESCRIPTION
When you go to http://www.tarletongillespie.org/essays/Gillespie%20-%20The%20Relevance%20of%20Algorithms.pdf to get redirected to http://www.tarletongillespie.org/cgi-sys/suspendedpage.cgi stating that 
'This web site has been suspended.

Web site owner please contact support@hostgo.com as soon as possible. Web site visitors we are very sorry for the inconvenience, please return soon.'

I found what I believe is a copy of the same article at http://mixedrealitycity.org/readings/Gillespie_TheRelevanceofAlgorithms.pdf so I have changed the link.
